### PR TITLE
Extract x, y, zoom destination coordinates from a bookmark if they are present

### DIFF
--- a/src/main/cpp/mainJNILib.cpp
+++ b/src/main/cpp/mainJNILib.cpp
@@ -636,6 +636,38 @@ JNI_FUNC(jlong, PdfiumCore, nativeGetBookmarkDestIndex)(JNI_ARGS, jlong docPtr, 
     return FPDFDest_GetDestPageIndex(doc->pdfDocument, dest);
 }
 
+JNI_FUNC(jfloatArray, PdfiumCore, nativeGetBookmarkDestCoords)(JNI_ARGS, jlong docPtr, jlong bookmarkPtr) {
+    DocumentFile *doc = reinterpret_cast<DocumentFile*>(docPtr);
+    FPDF_BOOKMARK bookmark = reinterpret_cast<FPDF_BOOKMARK>(bookmarkPtr);
+
+    FPDF_DEST dest = FPDFBookmark_GetDest(doc->pdfDocument, bookmark);
+    if (dest == NULL) {
+        return NULL;
+    }
+
+    FPDF_BOOL hasX, hasY, hasZoom;
+    FS_FLOAT x, y, zoom;
+
+    FPDF_BOOL success = FPDFDest_GetLocationInPage(dest, &hasX, &hasY, &hasZoom, &x, &y, &zoom);
+    if (!success) {
+        return NULL;
+    }
+
+    // Return array: [hasX, x, hasY, y, hasZoom, zoom]
+    jfloatArray result = env->NewFloatArray(6);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    jfloat buf[6] = {
+        (jfloat)hasX, (jfloat)x,
+        (jfloat)hasY, (jfloat)y,
+        (jfloat)hasZoom, (jfloat)zoom
+    };
+    env->SetFloatArrayRegion(result, 0, 6, buf);
+    return result;
+}
+
 JNI_FUNC(jlongArray, PdfiumCore, nativeGetPageLinks)(JNI_ARGS, jlong pagePtr) {
     FPDF_PAGE page = reinterpret_cast<FPDF_PAGE>(pagePtr);
     int pos = 0;

--- a/src/main/java/com/shockwave/pdfium/PdfDocument.java
+++ b/src/main/java/com/shockwave/pdfium/PdfDocument.java
@@ -60,6 +60,11 @@ public class PdfDocument {
         long pageIdx;
         long mNativePtr;
 
+        // Destination coordinates (null if not specified in PDF)
+        Float destX;
+        Float destY;
+        Float destZoom;
+
         public List<Bookmark> getChildren() {
             return children;
         }
@@ -74,6 +79,18 @@ public class PdfDocument {
 
         public long getPageIdx() {
             return pageIdx;
+        }
+
+        public Float getDestX() {
+            return destX;
+        }
+
+        public Float getDestY() {
+            return destY;
+        }
+
+        public Float getDestZoom() {
+            return destZoom;
         }
     }
 

--- a/src/main/java/com/shockwave/pdfium/PdfiumCore.java
+++ b/src/main/java/com/shockwave/pdfium/PdfiumCore.java
@@ -76,6 +76,8 @@ public class PdfiumCore {
 
     private native long nativeGetBookmarkDestIndex(long docPtr, long bookmarkPtr);
 
+    private native float[] nativeGetBookmarkDestCoords(long docPtr, long bookmarkPtr);
+
     private native Size nativeGetPageSizeByIndex(long docPtr, int pageIndex, int dpi);
 
     private native long[] nativeGetPageLinks(long pagePtr);
@@ -376,6 +378,15 @@ public class PdfiumCore {
         bookmark.mNativePtr = bookmarkPtr;
         bookmark.title = nativeGetBookmarkTitle(bookmarkPtr);
         bookmark.pageIdx = nativeGetBookmarkDestIndex(doc.mNativeDocPtr, bookmarkPtr);
+
+        /* If destination coordinates are avaliable, extract them */
+        float[] coords = nativeGetBookmarkDestCoords(doc.mNativeDocPtr, bookmarkPtr);
+        if (coords != null && coords.length == 6) {
+            if (coords[0] != 0) bookmark.destX = coords[1];
+            if (coords[2] != 0) bookmark.destY = coords[3];
+            if (coords[4] != 0) bookmark.destZoom = coords[5];
+        }
+
         tree.add(bookmark);
 
         Long child = nativeGetFirstChildBookmark(doc.mNativeDocPtr, bookmarkPtr);


### PR DESCRIPTION
PdfiumAndroid is not exposing all the properties of a bookmark. This adds extraction of destination coordinates with `FPDFDest_GetLocationInPage()`.

This adds an ability to display a document on a precise position where the bookmark was set and not just on the same page.